### PR TITLE
Replace Java 6 with Java 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Log in to your instance via SSH.
 Ensure that the following are installed:
  
  * Git client
- * Java runtime 6
+ * Java runtime 7
 
 Install the play framework on your EC2 instance:
 


### PR DESCRIPTION
Epub check doesn't work without java 7, so we should reflect that in the documentation